### PR TITLE
Feld für zusätzliche Optionen hinzugefügt

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -39,3 +39,6 @@ cookiedingsbums_select_link = Art des Link
 eLink = Externer Link
 iLink = Interner Link
 script-checkbox = CSS und JS automatisch einbinden
+custom_options = Benutzerdefinierte Optionen
+custom_options_notice = Hier können zusätzliche Optionen eingetragen werden. Für mögliche Optionen siehe
+json_not_valid = Die gegebenen Optionen liegen nicht im gültigen JSON-Format vor

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -40,3 +40,6 @@ cookiedingsbums_select_link = Type of link
 eLink = External Link
 iLink = Internal Link
 script-checkbox = Automatic integration of CSS and JS
+custom_options = Custom Options
+custom_options_notice = You can specify additional Options. For possible Options see
+json_not_valid = The given Options aren't valid JSON

--- a/lib/cookie_consent_functions.php
+++ b/lib/cookie_consent_functions.php
@@ -9,6 +9,14 @@ class cookie_consent {
 			return true;
 		}
 	}
+
+	public function checkJson($data) {
+	    if($data) {
+            json_decode($data);
+            return json_last_error() === JSON_ERROR_NONE;
+        }
+    }
+
 	protected function cookie_consent_get_css() {
 		$getFile = rex_url::base('assets/addons/cookie_consent/css/cookie_consent_insites.css');
 		$makeCssLink =  '<link rel="stylesheet" href="'.$getFile.'">';
@@ -43,31 +51,41 @@ class cookie_consent {
 		$main_color_scheme = 'style="background:'.rex_escape($color_background).'; color: '.rex_escape($color_main_content).';"';
 		$link_color_scheme = 'style="color: '.rex_escape($color_main_content).';"';
 		$button_color_scheme = 'style="background:'.rex_escape($color_button_background).'; color:'.rex_escape($color_button_content).';"';
-		
-		$code = '<pre><code>window.addEventListener("load", function(){
-		window.cookieconsent.initialise({
-		  "palette": {
-		    "popup": {
-		      "background": "'.rex_escape($color_background).'",
-		      "text": "'.rex_escape($color_main_content).'"
-		    },
-		    "button": {
-		      "background": "'.rex_escape($color_button_background).'",
-		      "text": "'.rex_escape($color_button_content).'"
-		    }
-		  },
-		  "theme": "'.$theme.'",
-		  "position": "'.$position.'",
-		  "content": {
-		    "message": "'.rex_escape($main_message).'",
-		    "dismiss": "'.rex_escape($button_content).'",
-		    "deny": "'.rex_escape($deny_content).'",
-		    "allow": "'.rex_escape($allow_content).'",
-		    "link": "'.rex_escape($link_content).'",
-		    "href": "'.rex_escape($externer_link).''.rex_escape($interner_link).'"
-		  },
-		  "type": "'.$mode.'"
-		})});
+
+        $object = [
+            "palette"  => [
+                "popup"  => [
+                    "background" => rex_escape($color_background),
+                    "text"       => rex_escape($color_main_content)
+                ],
+                "button" => [
+                    "background" => rex_escape($color_button_background),
+                    "text"       => rex_escape($color_button_content)
+                ]
+            ],
+            "theme"    => $theme,
+            "position" => $position,
+            "content"  => [
+                "message" => rex_escape($main_message),
+                "dismiss" => rex_escape($button_content),
+                "deny"    => rex_escape($deny_content),
+                "allow"   => rex_escape($allow_content),
+                "link"    => rex_escape($link_content),
+                "href"    => rex_escape($externer_link) . '' . rex_escape($interner_link)
+            ],
+            "type"     => $mode
+        ];
+
+        $custom_options = rex_config::get('cookie_consent', 'custom_options');
+        $custom_options = json_decode($custom_options);
+        if($custom_options) {
+            $object += (array) $custom_options;
+        }
+
+
+        $code = '<pre><code>window.addEventListener("load", function() {
+		    window.cookieconsent.initialise('.json_encode($object, JSON_PRETTY_PRINT).');
+		});
 		
 		</code></pre>';
 		
@@ -107,34 +125,41 @@ class cookie_consent {
 		$main_color_scheme = 'style="background:'.rex_escape($color_background).'; color: '.rex_escape($color_main_content).';"';
 		$link_color_scheme = 'style="color: '.rex_escape($color_main_content).';"';
 		$button_color_scheme = 'style="background:'.rex_escape($color_button_background).'; color:'.rex_escape($color_button_content).';"';
-		
-	
-		
-		$code = 		$cookie_consent_css. '' . $cookie_consent_js .'<script>
-		window.addEventListener("load", function(){
-		window.cookieconsent.initialise({
-		  "palette": {
-		    "popup": {
-		      "background": "'.rex_escape($color_background).'",
-		      "text": "'.rex_escape($color_main_content).'"
-		    },
-		    "button": {
-		      "background": "'.rex_escape($color_button_background).'",
-		      "text": "'.rex_escape($color_button_content).'"
-		    }
-		  },
-		  "theme": "'.$theme.'",
-		  "position": "'.$position.'",
-		  "content": {
-		    "message": "'.rex_escape($main_message).'",
-		    "dismiss": "'.rex_escape($button_content).'",
-		    "deny": "'.rex_escape($deny_content).'",
-		    "allow": "'.rex_escape($allow_content).'",
-		    "link": "'.rex_escape($link_content).'",
-		    "href": "'.rex_escape($externer_link).''.rex_escape($interner_link).'"
-		  },
-		  "type": "'.$mode.'"
-		})});
+
+        $object = [
+            "palette"  => [
+                "popup"  => [
+                    "background" => rex_escape($color_background),
+                    "text"       => rex_escape($color_main_content)
+                ],
+                "button" => [
+                    "background" => rex_escape($color_button_background),
+                    "text"       => rex_escape($color_button_content)
+                ]
+            ],
+            "theme"    => $theme,
+            "position" => $position,
+            "content"  => [
+                "message" => rex_escape($main_message),
+                "dismiss" => rex_escape($button_content),
+                "deny"    => rex_escape($deny_content),
+                "allow"   => rex_escape($allow_content),
+                "link"    => rex_escape($link_content),
+                "href"    => rex_escape($externer_link) . '' . rex_escape($interner_link)
+            ],
+            "type"     => $mode
+        ];
+
+        $custom_options = rex_config::get('cookie_consent', 'custom_options');
+        $custom_options = json_decode($custom_options);
+        if($custom_options) {
+            $object += (array) $custom_options;
+        }
+
+        $code = $cookie_consent_css. '' . $cookie_consent_js .'<script>
+            window.addEventListener("load", function() {
+            window.cookieconsent.initialise('.json_encode($object, JSON_PRETTY_PRINT).');
+		});
 		
 		</script>';
 		

--- a/pages/configuration.php
+++ b/pages/configuration.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * @var rex_addon $this
+ */
+
 $content = '';
 $buttons = '';
 $cookie_consent = rex_addon::get('cookie_consent');
@@ -23,6 +27,7 @@ if (rex_post('formsubmit', 'string') == '1') {
         ['deny_content', 'string'],
         ['allow_content', 'string'],
         ['script_checkbox', 'string'],
+        ['custom_options', 'string'],
     ]));
 
     echo rex_view::success($this->i18n('config_saved_cookie'));
@@ -38,6 +43,10 @@ if (rex_post('formsubmit', 'string') == '1') {
 	if($this->getConfig('cookiedingsbums_select_link') == 'iLink') {
 			$cookie_consent->setConfig('eLink', '');
 	}
+	if($cookie_consent_functions->checkJson($this->getConfig('custom_options')) === false) {
+        $content .= rex_view::warning($this->i18n('json_not_valid'));
+        $cookie_consent->setConfig('custom_options','');
+    }
 
 
 // Einfaches Textfeld
@@ -280,6 +289,17 @@ $formElements[] = $n;
 $fragment = new rex_fragment();
 $fragment->setVar('elements', $formElements, false);
 $content .= $fragment->parse('core/form/checkbox.php');
+
+
+/* Custom Options */
+$formElements = [];
+$n = [];
+$n['label'] = '<label for="custom-options">' . $this->i18n('custom_options') . '</label>';
+$n['field'] = '<textarea class="form-control" id="custom-options" name="config[custom_options]">' . $this->getConfig('custom_options') . '</textarea><i class="custom_options_notice">'.$this->i18n('custom_options_notice').' <a href="https://cookieconsent.insites.com/documentation/javascript-api/" target="_blank">JavaScript API</a></i>';
+$formElements[] = $n;
+$fragment = new rex_fragment();
+$fragment->setVar('elements', $formElements, false);
+$content .= $fragment->parse('core/form/container.php');
 
 
 // Save-Button


### PR DESCRIPTION
Ein zusätzliches Textfeld hinzugefügt um weitere Optionen, die aktuell nicht durch die Einstellungsmöglichkeiten abgedeckt sind, zu ermöglichen.

Im Textfeld kann ein JSON-Object eingetragen werden, dass zu den gesetzten Einstellungen bei der Ausgabe des Cookie-Consent-Codes hinzugefügt wird.