### PR TITLE
Erweiterung um automatisches einbinden (EP)

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -10,3 +10,7 @@ if (rex::isBackend() && rex_be_controller::getCurrentPage() == 'cookie_consent/c
 		rex_view::addCssFile($this->getAssetsUrl('css/cookie_consent_backend.css'));
 		rex_view::addJsFile($this->getAssetsUrl('js/cookie_consent_backend.js'));
     }
+
+if(!rex::isBackend() && rex_config::get('cookie_consent', 'script_checkbox') == '1') {
+	rex_extension::register('OUTPUT_FILTER', 'cookie_consent::ep_call', rex_extension::LATE);
+}

--- a/lib/cookie_consent_functions.php
+++ b/lib/cookie_consent_functions.php
@@ -91,6 +91,16 @@ class cookie_consent {
 		
 		return $code;
 	}
+
+	public static function ep_call($rex_ep) {
+		$subject = $rex_ep->getSubject();
+
+		$s = self::cookie_consent_output();
+
+		$subject = str_replace('</head>', $s.PHP_EOL.'</head>', $subject);
+		$rex_ep->setSubject($subject);
+	}
+
 	public static function cookie_consent_output() {
 		$cookie = new cookie_consent();
 		$cookie_consent_css = $cookie->cookie_consent_get_css();


### PR DESCRIPTION
Erweiterung um automatisches einbinden von css und js Dateien. Berücksichtigt die Checkbox aus dem Backend ("CSS und JS automatisch einbinden").