### PR TITLE
Nicht benötigte Variable entfernt

### DIFF
--- a/pages/configuration.php
+++ b/pages/configuration.php
@@ -63,7 +63,6 @@ $filterContent = $fragment->parse('core/form/container.php');
 $fragment = new rex_fragment();
 $fragment->setVar('title', $this->i18n('settings_for'));
 $fragment->setVar('body', $filterContent, false);
-$fragment->setVar('buttons', $buttons, false);
 echo $fragment->parse('core/page/section.php');
 
 $context = rex_context::restore();


### PR DESCRIPTION
Die Variable `$buttons` ist nicht vorhanden und wird auch nicht benötigt. Daher kann der zugehörige Code entfernt werden.

fixes #49 