### PR TITLE
Benutzerdefinierte Optionen

### DIFF
--- a/lib/cookie_consent.php
+++ b/lib/cookie_consent.php
@@ -149,14 +149,14 @@ class cookie_consent
                 ],
             ];
         }
+        $jsonConfig = json_encode($object, JSON_PRETTY_PRINT);
 
         $custom_options = rex_config::get('cookie_consent', $clang_prefix.'custom_options');
-        $custom_options = json_decode($custom_options);
-        if ($custom_options) {
-            $object += (array) $custom_options;
+        if ($custom_options && $custom_options != '') {
+            $jsonConfig = substr($jsonConfig, 0, strlen($jsonConfig) - 2) . ','.PHP_EOL.$custom_options.PHP_EOL . '}';
         }
 
-        $jsConfigCode = 'window.cookieconsent.initialise('.json_encode($object, JSON_PRETTY_PRINT).');';
+        $jsConfigCode = 'window.cookieconsent.initialise('.$jsonConfig.');';
 
         if ($codepreview === true) {
             return $jsConfigCode;

--- a/pages/configuration.php
+++ b/pages/configuration.php
@@ -136,10 +136,6 @@ if ($this->getConfig($clang_prefix.'select_link') == 'eLink') {
 if ($this->getConfig($clang_prefix.'select_link') == 'iLink') {
     $cookie_consent->setConfig($clang_prefix.'eLink', '');
 }
-if ($cookie_consent_functions->checkJson($this->getConfig($clang_prefix.'custom_options')) === false) {
-    $content .= rex_view::warning($this->i18n('json_not_valid'));
-    $cookie_consent->setConfig($clang_prefix.'custom_options', '');
-}
 
 $content .= '<fieldset><legend>'.$this->i18n('status').'</legend>';
 
@@ -418,7 +414,10 @@ $content .= $fragment->parse('core/form/checkbox.php');
 $formElements = [];
 $n = [];
 $n['label'] = '<label for="custom-options">' . $this->i18n('custom_options') . '</label>';
-$n['field'] = '<textarea class="form-control" id="custom-options" name="config['.$clang_prefix.'custom_options]">' . $this->getConfig($clang_prefix.'custom_options') . '</textarea><i class="custom_options_notice">'.$this->i18n('custom_options_notice').' <a href="https://cookieconsent.insites.com/documentation/javascript-api/" target="_blank">JavaScript API</a></i>';
+$n['field'] = '<div class="input-group"><div class="input-group-addon">{</div>';
+$n['field'] .= '<textarea class="form-control" id="custom-options" name="config['.$clang_prefix.'custom_options]">' . $this->getConfig($clang_prefix.'custom_options') . '</textarea>';
+$n['field'] .= '<div class="input-group-addon">}</div></div>';
+$n['field'] .= '<i class="custom_options_notice">'.$this->i18n('custom_options_notice').' <a href="https://cookieconsent.insites.com/documentation/javascript-api/" target="_blank">JavaScript API</a></i>';
 $formElements[] = $n;
 $fragment = new rex_fragment();
 $fragment->setVar('elements', $formElements, false);

--- a/update.php
+++ b/update.php
@@ -28,6 +28,15 @@ foreach ($configs as $key => $value) {
         }
         $this->setConfig($prefix.$key, $value);
     }
+    if ($key == $prefix.'custom_options' && $value != '') {
+        if (substr($value, 0, 1) === '{') {
+            $value = substr($value, 1);
+        }
+        if (substr($value, strlen($value) - 1, 1) === '}') {
+            $value = substr($value, 0, strlen($value) - 1);
+        }
+        $this->setConfig($key, $value);
+    }
 }
 if (!$this->hasConfig($prefix.'status')) {
     $this->setConfig($prefix.'status', '1');


### PR DESCRIPTION
Benutzerdefinierte Optionen überarbeitet, sodass die JSON-Validierung nicht mehr stattfindet, da diese keine JS-Callbacks zulässt. Jetzt werden die Optionen als "Text" den Konfiguration angehangen. Hierdurch sind jetzt auch JS-Callbacks möglich.

Beispiel:
```
onStatusChange: function(status) {
    console.log(this.hasConsented() ? 'enable cookies' : 'disable cookies');
}
```
wird in der Ausgabe zu:
```
window.addEventListener("load", function() {
    window.cookieconsent.initialise({
        [...],
        onStatusChange: function(status) {
              console.log(this.hasConsented() ? 'enable cookies' : 'disable cookies');
        }
    });
});
```
fixes #41 