### PR TITLE
CSS und JS nach gesetztem Cookie nicht mehr ausgeben

### DIFF
--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -76,3 +76,5 @@ cookie_consent_test_embed_notice = Der folgende Code kann verwendet werden um di
 cookie_consent_global_configuration = Globale Einstellungen
 cookie_consent_testmode = Testmodus aktivieren
 cookie_consent_testmode_notice = Wenn der Testmodus aktiv ist, setzt der Cookie-Banner kein Cookie. Dies erlaubt einfacheres Testen des Banners im Frontend.
+cookie_consent_hide_on_cookie = Banner CSS und JS nach Bestätigung nicht laden
+cookie_consent_hide_on_cookie_notice = Wenn der Banner-Cookie gesetzt wurde, wird der Banner CSS- und JS-Code im Frontend nicht mehr ausgegeben.

--- a/lib/cookie_consent.php
+++ b/lib/cookie_consent.php
@@ -85,7 +85,7 @@ class cookie_consent
         }
 
         $status = self::getConfig('status');
-        if ($status != '1') {
+        if ($status != '1' || (self::getGlobalConfig('hide_on_cookie') === '1' && isset($_COOKIE[self::COOKIE_NAME]))) {
             return '';
         }
 

--- a/lib/cookie_consent.php
+++ b/lib/cookie_consent.php
@@ -85,7 +85,7 @@ class cookie_consent
         }
 
         $status = self::getConfig('status');
-        if ($status != '1' || (self::getGlobalConfig('hide_on_cookie') === '1' && isset($_COOKIE[self::COOKIE_NAME]))) {
+        if ($status != '1' || (self::getGlobalConfig('hide_on_cookie') === '1' && isset($_COOKIE[self::COOKIE_NAME]) && !$codepreview)) {
             return '';
         }
 

--- a/pages/global_configuration.php
+++ b/pages/global_configuration.php
@@ -10,6 +10,7 @@ $context = rex_context::restore();
 if ($context->getParam('save')) {
     $this->setConfig(rex_post('config', [
         ['global_testmode', 'string', '0'],
+        ['global_hide_on_cookie', 'string', '0'],
     ]));
 }
 $formElements = [];
@@ -19,6 +20,13 @@ $formElements[] = [
     'label' => '<label for="testmode">'.$this->i18n('testmode').'</label>',
     'field' => '<input type="checkbox" id="testmode" name="config[global_testmode]"' . (cookie_consent::getGlobalConfig('testmode', '0') == '1' ? ' checked="checked"' : '') . ' value="1" />',
     'note' => $this->i18n('testmode_notice'),
+];
+
+// Hide JS and CSS if Cookie is set
+$formElements[] = [
+    'label' => '<label for="hide_on_cookie">'.$this->i18n('hide_on_cookie').'</label>',
+    'field' => '<input type="checkbox" id="hide_on_cookie" name="config[global_hide_on_cookie]"' . (cookie_consent::getGlobalConfig('hide_on_cookie', '0') == '1' ? ' checked="checked"' : '') . ' value="1" />',
+    'note' => $this->i18n('hide_on_cookie_notice'),
 ];
 
 $fragment = new rex_fragment();


### PR DESCRIPTION
closes #64 

Konfigurierbar im Backend, dass wenn der Banner bestätigt wurde, kein CSS und JS durch den Cookie-Consent im Frontend ausgegeben wird.