### PR TITLE
Testmodus fix

### DIFF
--- a/lib/cookie_consent.php
+++ b/lib/cookie_consent.php
@@ -88,7 +88,7 @@ class cookie_consent
         }
 
         $status = self::getConfig('status');
-        if ($status != '1' || (self::getGlobalConfig('hide_on_cookie') === '1' && isset($_COOKIE[self::COOKIE_NAME]) && !$codepreview)) {
+        if ($status != '1' || (self::getGlobalConfig('hide_on_cookie') === '1' && self::getGlobalConfig('testmode') !== '1' && isset($_COOKIE[self::COOKIE_NAME]) && !$codepreview)) {
             return '';
         }
 


### PR DESCRIPTION
Wenn der Testmodus und "Banner CSS und JS nach Bestätigung nicht laden" beide aktiviert waren, wurde nach einmaliger Bestätigung der Banner nicht mehr angezeigt.

fixes #92 