### PR TITLE
Extension Points hinzugefügt

### DIFF
--- a/lib/cookie_consent.php
+++ b/lib/cookie_consent.php
@@ -181,7 +181,7 @@ class cookie_consent
             $output .= '<script async>window.addEventListener("load", function() {'.$jsConfigCode.'});</script>';
         }
 
-        return $output;
+        return rex_extension::registerPoint(new rex_extension_point('COOKIE_CONTENT_OUTPUT', $output));
     }
 
     public static function getMode()
@@ -212,6 +212,10 @@ class cookie_consent
 
     public static function removeCookies()
     {
+        if (false === rex_extension::registerPoint(new rex_extension_point('COOKIE_CONSENT_COOKIE_REMOVE', true))) {
+            return false;
+        }
+
         // If user is logged in, skip
         if (session_name() != '' && rex_backend_login::hasSession()) {
             return;


### PR DESCRIPTION
neue EPs hinzufefügt:
- `COOKIE_CONSENT_COOKIE_REMOVE` erlaubt es das entfernen von Cookies zu verhindern. Hierfür wird als return Subject `false` erwartet.
- `COOKIE_CONSENT_OUTPUT` erlaubt es den Cookie-Consent Output zu manipulieren. Möglicher Use-Case: den Banner durch Rückgabe eines leeren Strings auf diversen Seiten nicht ausgeben. Könnte ein Workaround für #73 sein.